### PR TITLE
fix: use token_by_index dict instead of list index in _get_token_prices

### DIFF
--- a/hyperliquid_positions.py
+++ b/hyperliquid_positions.py
@@ -297,6 +297,10 @@ def _get_token_prices() -> dict[str, float]:
     """Get token prices from market data."""
     metadata, market_data = hyperliquid_utils.info.spot_meta_and_asset_ctxs()
     tokens, universe = metadata["tokens"], metadata["universe"]
+    token_by_index: dict[int, dict[str, Any]] = {}
+    for i, token in enumerate(tokens):
+        key = token.get("index", i)
+        token_by_index[key] = token
     market_data_map = {i: data for i, data in enumerate(market_data)}
     token_prices = {"USDC": 1.0}
 
@@ -305,7 +309,9 @@ def _get_token_prices() -> dict[str, float]:
         if not market or not (mid_price := float(market.get("midPx") or 0)):
             continue
 
-        base_token, quote_token = (tokens[idx]["name"] for idx in pair["tokens"])
+        base_token, quote_token = (
+            token_by_index[idx]["name"] for idx in pair["tokens"]
+        )
 
         if quote_token == "USDC":
             token_prices[base_token] = mid_price

--- a/tests/test_hyperliquid_positions.py
+++ b/tests/test_hyperliquid_positions.py
@@ -209,6 +209,37 @@ class TestGetTokenPrices:
         assert "AAA" not in prices
         assert "BBB" not in prices
 
+    def test_non_sequential_token_indices(self) -> None:
+        """Verify no IndexError when spot_meta token indices skip values.
+
+        The old code did tokens[idx]["name"] (list index by position),
+        which crashed when token indices were not sequential starting
+        from 0 (e.g., indices 0, 2, 5 instead of 0, 1, 2).
+        """
+        metadata = {
+            "tokens": [
+                {"index": 0, "name": "USDC"},
+                {"index": 2, "name": "HYPE"},  # non-sequential
+                {"index": 5, "name": "SOL"},   # non-sequential
+            ],
+            "universe": [
+                {"tokens": [2, 0], "index": 0},
+                {"tokens": [5, 0], "index": 1},
+            ],
+        }
+        market_data: list[dict[str, str]] = [
+            {"midPx": "25.0"},
+            {"midPx": "150.0"},
+        ]
+
+        with patch("hyperliquid_positions.hyperliquid_utils") as mock_hl:
+            mock_hl.info.spot_meta_and_asset_ctxs.return_value = (metadata, market_data)
+            prices = _get_token_prices()
+
+        assert prices["USDC"] == 1.0
+        assert prices["HYPE"] == 25.0
+        assert prices["SOL"] == 150.0
+
 
 class TestFormatPortfolioMessage:
     def test_basic_message(self):


### PR DESCRIPTION
## Summary

Fixes the same `IndexError: list index out of range` pattern in the bot code that the SDK upgrade fixed — `_get_token_prices()` in `hyperliquid_positions.py` was indexing `tokens[idx]["name"]` by position, which crashes when Hyperliquid's API returns non-sequential token indices.

### Root cause
```python
# Before (crashes when indices skip values):
base_token, quote_token = (tokens[idx]["name"] for idx in pair["tokens"])

# After (dict lookup by key — safe):
token_by_index = {token["index"]: token for token in tokens}
base_token, quote_token = (token_by_index[idx]["name"] for idx in pair["tokens"])
```

### Changes
- `hyperliquid_positions.py`: build `token_by_index` dict, fall back to list position when `index` key is absent (backward compat)
- `tests/test_hyperliquid_positions.py`: new `test_non_sequential_token_indices` test

### Verification
- ✅ All 623 tests pass (614 existing + 9 SDK compat tests + 1 new)