### PR TITLE
refactor: multi-dex trading with isolated-only token support

### DIFF
--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -178,15 +178,38 @@ class HyperliquidUtils:
         return None
 
     def get_coins_with_open_positions(self) -> List[str]:
-        user_state = self.info.user_state(self.address)
-        return [asset_position['position']['coin'] for asset_position in user_state.get("assetPositions", [])]
+        """Get coins with open positions across all DEXes."""
+        coins: list[str] = []
+        dexes: list[str] = [""] + self._extra_dexes
+        for dex in dexes:
+            user_state = self.info.user_state(self.address, dex=dex)
+            coins.extend(
+                ap['position']['coin']
+                for ap in user_state.get("assetPositions", [])
+            )
+        return coins
 
     def get_coins_by_traded_volume(self) -> List[str]:
+        """Get coins available for trading across all DEXes, sorted by volume."""
+        # Default DEX coins
         response_data: Any = self.info.meta_and_asset_ctxs()
         universe: List[Dict[str, Any]] = response_data[0]['universe']
         coin_data: List[Dict[str, Any]] = response_data[1]
+        coins: list[tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
 
-        coins: List[Tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
+        # Extra DEX coins
+        for dex in self._extra_dexes:
+            try:
+                dex_ctxs = self.info.meta_and_asset_ctxs(dex=dex)
+                dex_universe = dex_ctxs[0]['universe']
+                dex_coin_data = dex_ctxs[1]
+                coins.extend(
+                    (u["name"], float(c.get("dayNtlVlm", 0)))
+                    for u, c in zip(dex_universe, dex_coin_data)
+                )
+            except Exception as e:
+                logger.warning(f"Failed to fetch coins for DEX '{dex}': {e}")
+
         sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)
         return [coin[0] for coin in reversed(sorted_coins[:75])]
 

--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -31,6 +31,7 @@ class HyperliquidUtils:
         self.address: str = user_vault if user_vault is not None else user_wallet
 
         self._info: Optional[InfoProxy] = None
+        self._exchange_cache: dict[str, Exchange] = {}
         self._extra_dexes: list[str] = [
             s.strip()
             for s in os.environ.get("HTB_EXTRA_DEXES", "xyz").split(",")
@@ -67,15 +68,70 @@ class HyperliquidUtils:
         logger.warning(f"Websocket closed: {close_msg}")
         telegram_utils.send_and_exit("Websocket closed, restarting the application...")
 
-    def get_exchange(self) -> Optional[Exchange]:
+    def get_exchange(self, dex: str = "") -> Optional[Exchange]:
+        """Get or create a cached Exchange for the given perp DEX.
+
+        Args:
+            dex: The perp DEX name (e.g. '' for default, 'xyz', 'flx').
+                 Exchanges are cached per dex name.
+
+        Returns:
+            Exchange instance or None if HTB_KEY_FILE is not configured.
+        """
+        if dex in self._exchange_cache:
+            return self._exchange_cache[dex]
+
         key_file: Optional[str] = os.environ.get("HTB_KEY_FILE")
         if key_file is not None and os.path.isfile(key_file):
             with open(key_file, 'r') as file:
                 file_content: str = file.read()
                 ascii_only: str = file_content.encode("ascii", "ignore").decode("ascii").strip()
                 account: LocalAccount = eth_account.Account.from_key(ascii_only)
-                return Exchange(account, constants.MAINNET_API_URL, vault_address=os.environ.get("HTB_USER_VAULT"), account_address=os.environ["HTB_USER_WALLET"])
+                perp_dexs = [dex] if dex else None  # None = default DEX only
+                exchange = Exchange(
+                    account, constants.MAINNET_API_URL,
+                    vault_address=os.environ.get("HTB_USER_VAULT"),
+                    account_address=os.environ["HTB_USER_WALLET"],
+                    perp_dexs=perp_dexs,
+                )
+                self._exchange_cache[dex] = exchange
+                return exchange
         return None
+
+    @staticmethod
+    def dex_supported(coin: str) -> Optional[str]:
+        """Detect the perp DEX a coin belongs to based on its prefix.
+
+        Coins from builder-deployed perp DEXes use the ``{dex_name}:`` prefix
+        (e.g. ``xyz:AAPL``, ``xyz:SPCX``).  Default DEX coins have no prefix.
+
+        Returns:
+            The dex name (e.g. 'xyz', 'flx') or None for the default DEX.
+        """
+        if ":" in coin:
+            parts = coin.split(":", 1)
+            if parts[0] and parts[1]:
+                return parts[0]
+        return None
+
+    @staticmethod
+    def strip_dex_prefix(coin: str) -> str:
+        """Strip the ``{dex_name}:`` prefix from a coin name."""
+        if ":" in coin:
+            return coin.split(":", 1)[1]
+        return coin
+
+    def get_isolated_only(self, coin: str) -> bool:
+        """Check if a coin is isolated-only (can't use cross margin).
+
+        Queries the meta for the relevant DEX to check the onlyIsolated flag.
+        """
+        dex = self.dex_supported(coin) or ""
+        meta = self.info.meta(dex=dex)
+        for asset_info in meta.get("universe", []):
+            if asset_info["name"] == coin:
+                return bool(asset_info.get("onlyIsolated", False))
+        return False
 
     def get_sz_decimals(self) -> Dict[str, int]:
         meta: Dict[str, Any] = self.info.meta()

--- a/tests/test_hyperliquid_trade.py
+++ b/tests/test_hyperliquid_trade.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from telegram.ext import ConversationHandler
@@ -988,6 +989,7 @@ class TestCloseAllPositionsCore:
         mock_exchange = MagicMock()
 
         with patch('trade_execution.hyperliquid_utils') as mock_hl:
+            mock_hl.extra_dexes.return_value = []
             mock_hl.info.user_state.return_value = {'assetPositions': []}
             mock_hl.address = "test_address"
 
@@ -1000,6 +1002,7 @@ class TestCloseAllPositionsCore:
         mock_exchange = MagicMock()
 
         with patch('trade_execution.hyperliquid_utils') as mock_hl:
+            mock_hl.extra_dexes.return_value = []
             mock_hl.info.user_state.return_value = {
                 'assetPositions': [
                     {'position': {'coin': 'BTC'}},
@@ -1019,6 +1022,7 @@ class TestCloseAllPositionsCore:
         mock_exchange = MagicMock()
 
         with patch('trade_execution.hyperliquid_utils') as mock_hl:
+            mock_hl.extra_dexes.return_value = []
             mock_hl.info.user_state.return_value = {
                 'assetPositions': [
                     {'position': {}},  # Missing coin
@@ -1071,6 +1075,7 @@ class TestExitPosition:
 
         with patch('trade_conversation.hyperliquid_utils') as mock_hl, \
                 patch('trade_conversation.telegram_utils') as mock_tg:
+            mock_hl.extra_dexes.return_value = []
             mock_hl.info.user_state.return_value = {'assetPositions': []}
             mock_hl.address = "test_address"
             mock_tg.reply = AsyncMock()
@@ -1087,6 +1092,7 @@ class TestExitPosition:
 
         with patch('trade_conversation.hyperliquid_utils') as mock_hl, \
                 patch('trade_conversation.telegram_utils') as mock_tg:
+            mock_hl.extra_dexes.return_value = []
             mock_hl.info.user_state.return_value = {
                 'assetPositions': [
                     {'position': {'coin': 'BTC'}},

--- a/tests/test_hyperliquid_utils.py
+++ b/tests/test_hyperliquid_utils.py
@@ -187,6 +187,7 @@ class TestHyperliquidUtilsPositions:
                 patch('hyperliquid_utils.utils.Info') as mock_info:
             from hyperliquid_utils.utils import HyperliquidUtils
             instance = HyperliquidUtils()
+            instance._extra_dexes = []
             instance.info.user_state = MagicMock(return_value=mock_user_state)  # type: ignore[attr-defined]
             result = instance.get_coins_with_open_positions()
             assert result == ["BTC", "ETH"]
@@ -202,6 +203,7 @@ class TestHyperliquidUtilsCoins:
                 patch('hyperliquid_utils.utils.Info') as mock_info:
             from hyperliquid_utils.utils import HyperliquidUtils
             instance = HyperliquidUtils()
+            instance._extra_dexes = []
             instance.info.meta_and_asset_ctxs = MagicMock(return_value=mock_response)  # type: ignore[attr-defined]
             result = instance.get_coins_by_traded_volume()
             assert result == ["BTC", "SOL", "ETH"]

--- a/trade_conversation.py
+++ b/trade_conversation.py
@@ -30,8 +30,9 @@ def _has_sl_tp_set(context: ContextType) -> bool:
 
 
 def _get_mid_price(coin: str) -> float:
-    """Get current mid price for a coin."""
-    return float(hyperliquid_utils.info.all_mids()[coin])
+    """Get current mid price for a coin, resolving the correct DEX."""
+    dex = hyperliquid_utils.dex_supported(coin) or ""
+    return float(hyperliquid_utils.info.all_mids(dex=dex)[coin])
 
 
 def _is_long_position(context: ContextType) -> bool:
@@ -109,7 +110,8 @@ async def _process_amount_selection(query: CallbackQuery, context: ContextType, 
     """Process the amount selection and determine next step."""
     context.user_data["amount"] = amount  # type: ignore
     coin = context.user_data.get("selected_coin", "")  # type: ignore
-    user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address)
+    dex = hyperliquid_utils.dex_supported(coin) or ""
+    user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address, dex=dex)
     current_leverage = hyperliquid_utils.get_leverage(user_state, coin)
 
     if current_leverage is not None:
@@ -144,7 +146,8 @@ async def _proceed_after_leverage_set(query: CallbackQuery, context: ContextType
 async def _prompt_for_leverage(query: CallbackQuery, coin: str) -> int:
     """Prompt user to select leverage for the given coin."""
     try:
-        meta: List[Dict[str, Any]] = hyperliquid_utils.info.meta()
+        dex = hyperliquid_utils.dex_supported(coin) or ""
+        meta: List[Dict[str, Any]] = hyperliquid_utils.info.meta(dex=dex)
         asset_info_map = {
             info["name"]: int(info["maxLeverage"])
             for info in meta.get("universe", [])  # type: ignore
@@ -169,7 +172,8 @@ async def selected_leverage(update: Update, context: ContextType) -> int:
     async def process(query: CallbackQuery, leverage: int) -> int:
         context.user_data["leverage"] = leverage  # type: ignore
         coin = context.user_data.get("selected_coin", "")  # type: ignore
-        user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address)
+        dex = hyperliquid_utils.dex_supported(coin) or ""
+        user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address, dex=dex)
         return await _proceed_after_leverage_set(query, context, user_state, coin)
     return await _handle_callback_selection(update, int, "Invalid leverage.", process)
 
@@ -234,9 +238,10 @@ async def _after_stop_loss_set(update: Update, context: ContextType, coin: str, 
 
 async def _after_take_profit_set(update: Update, context: ContextType, coin: str, mid: float) -> int:
     """Action after take profit is set - open the order."""
+    dex = hyperliquid_utils.dex_supported(coin) or ""
     await open_order(
         context.user_data,  # type: ignore
-        hyperliquid_utils.info.user_state(hyperliquid_utils.address),
+        hyperliquid_utils.info.user_state(hyperliquid_utils.address, dex=dex),
         mid,
         _is_long_position(context),
         skip_sl_tp_prompt()

--- a/trade_conversation.py
+++ b/trade_conversation.py
@@ -294,8 +294,18 @@ async def exit_all_positions(update: Update, context: ContextType) -> None:
 
 
 async def exit_position(update: Update, context: ContextType) -> int:
-    user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address)
-    coins = sorted({asset_position['position']['coin'] for asset_position in user_state.get("assetPositions", [])})
+    """Show positions from all DEXes (default + extra) for closing."""
+    coins: list[str] = []
+    dexes_to_check: list[str] = [""] + hyperliquid_utils.extra_dexes()
+
+    for dex in dexes_to_check:
+        user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address, dex=dex)
+        coins.extend(
+            ap['position']['coin']
+            for ap in user_state.get("assetPositions", [])
+        )
+
+    coins = sorted(set(coins))
 
     if not coins:
         await telegram_utils.reply(update, 'No positions to close')
@@ -310,20 +320,34 @@ async def exit_position(update: Update, context: ContextType) -> int:
 
 async def _close_position_with_exchange(
     query: CallbackQuery,
-    close_action: Any,
-    error_prefix: str
+    coin: Optional[str],
 ) -> int:
-    """Helper to close position(s) with exchange error handling."""
+    """Close position(s) on the correct DEX with error handling.
+
+    Args:
+        coin: The coin to close. If None or 'all', closes all positions.
+    """
     try:
-        exchange = hyperliquid_utils.get_exchange()
-        if exchange:
-            close_action(exchange)
+        if coin and coin != 'all':
+            # Close a specific coin on its DEX
+            dex = hyperliquid_utils.dex_supported(coin) or ""
+            exchange = hyperliquid_utils.get_exchange(dex=dex)
+            if not exchange:
+                await query.edit_message_text("Exchange is not enabled")
+                return ConversationHandler.END
+            exchange.market_close(coin)
             await query.delete_message()
         else:
-            await query.edit_message_text("Exchange is not enabled")
+            # Close all positions across all DEXes
+            exchange = hyperliquid_utils.get_exchange()
+            if not exchange:
+                await query.edit_message_text("Exchange is not enabled")
+                return ConversationHandler.END
+            close_all_positions_core(exchange)
+            await query.delete_message()
     except Exception as e:
         logger.critical(e, exc_info=True)
-        await query.edit_message_text(f"{error_prefix}: {str(e)}")
+        await query.edit_message_text(f"Failed to close position: {str(e)}")
     return ConversationHandler.END
 
 
@@ -331,11 +355,7 @@ async def exit_selected_coin(update: Update, context: ContextType) -> int:
     async def process(query: CallbackQuery, coin: str) -> int:
         if coin == 'all':
             await query.edit_message_text("Closing all positions...")
-            return await _close_position_with_exchange(
-                query, close_all_positions_core, "Failed to exit all positions"
-            )
+            return await _close_position_with_exchange(query, None)
         await query.edit_message_text(f"Closing {coin}...")
-        return await _close_position_with_exchange(
-            query, lambda ex: ex.market_close(coin), f"Failed to exit {coin}"
-        )
+        return await _close_position_with_exchange(query, coin)
     return await _handle_callback_selection(update, None, "Invalid coin.", process)

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -35,10 +35,15 @@ def get_order_error_message(result: Any) -> str:
     return "Unknown order error"
 
 
-def calculate_available_margin() -> float:
-    perp_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address)
-    cross_margin_account_value = float(perp_state['crossMarginSummary']['accountValue'])
-    total_margin_used = float(perp_state['crossMarginSummary']['totalMarginUsed'])
+def calculate_available_margin(dex: str = "") -> float:
+    """Calculate available margin for trading on a specific perp DEX.
+
+    Args:
+        dex: The perp DEX name ('' for default Hyperliquid DEX).
+    """
+    user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address, dex=dex)
+    cross_margin_account_value = float(user_state['crossMarginSummary']['accountValue'])
+    total_margin_used = float(user_state['crossMarginSummary']['totalMarginUsed'])
     return max(cross_margin_account_value - total_margin_used, 0.0)
 
 
@@ -56,6 +61,20 @@ def _validate_order_context(user_data: Dict[str, Any]) -> Tuple[bool, str]:
     return True, ""
 
 
+def _determine_leverage_mode(coin: str) -> tuple[str, bool]:
+    """Determine the correct DEX and leverage mode (cross/isolated) for a coin.
+
+    Returns:
+        (dex_name, is_cross) where dex_name is '' for the default DEX.
+        is_cross is False for isolated-only tokens regardless of settings.
+    """
+    dex = hyperliquid_utils.dex_supported(coin) or ""
+    only_isolated = hyperliquid_utils.get_isolated_only(coin)
+    use_isolated = os.getenv('HTB_USE_ISOLATED_LEVERAGE', 'True') == 'True'
+    is_cross = not use_isolated and not only_isolated
+    return dex, is_cross
+
+
 async def open_order(user_data: Dict[str, Any], user_state: Dict[str, Any], mid: float, is_long: bool, skip_sl_tp: bool) -> None:
     is_valid, error = _validate_order_context(user_data)
     if not is_valid:
@@ -70,16 +89,16 @@ async def open_order(user_data: Dict[str, Any], user_state: Dict[str, Any], mid:
 
     message = await telegram_utils.send(f"Opening {'long' if is_long else 'short'} for {selected_coin}...")
     try:
-        exchange = hyperliquid_utils.get_exchange()
+        dex, is_cross = _determine_leverage_mode(selected_coin)
+        exchange = hyperliquid_utils.get_exchange(dex=dex)
         if not exchange:
             await telegram_utils.send("Exchange is not enabled")
             return
 
-        available_margin = calculate_available_margin()
+        available_margin = calculate_available_margin(dex=dex)
         balance_to_use = available_margin * amount / 100.0
         leverage: int = user_data.get('leverage', 1)
-        use_isolated_leverage = os.getenv('HTB_USE_ISOLATED_LEVERAGE', 'True') == 'True'
-        update_leverage_result = exchange.update_leverage(leverage, selected_coin, not use_isolated_leverage)
+        update_leverage_result = exchange.update_leverage(leverage, selected_coin, is_cross)
         logger.info(update_leverage_result)
 
         sz_decimals = hyperliquid_utils.get_sz_decimals()
@@ -158,22 +177,44 @@ def place_stop_loss_and_take_profit_orders(
 
 
 def close_all_positions_core(exchange: Any) -> Tuple[List[str], List[Tuple[str, str]]]:
-    """Close all open positions without doing any messaging."""
+    """Close all open positions across all configured DEXes.
 
+    Closes positions on the default DEX plus any extra DEXes (e.g. XYZ).
+    Uses the provided exchange for the default DEX and creates/caches
+    per-DEX exchanges for the rest.
+
+    Returns:
+        (closed_coins, errors) where errors is a list of (coin, error_message).
+    """
     closed: List[str] = []
     errors: List[Tuple[str, str]] = []
 
-    user_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address)
+    # Collect positions from default DEX + all extra DEXes
+    dexes_to_check: list[str] = [""] + hyperliquid_utils.extra_dexes()
 
-    for asset_position in user_state.get("assetPositions", []):
-        coin = asset_position.get('position', {}).get('coin')
-        if not coin:
-            continue
-        try:
-            exchange.market_close(coin)
-            closed.append(coin)
-        except Exception as e:  # pragma: no cover - exchange errors depend on external service
-            logger.error(f"Failed to close {coin}: {e}", exc_info=True)
-            errors.append((coin, str(e)))
+    for dex in dexes_to_check:
+        dex_state = hyperliquid_utils.info.user_state(hyperliquid_utils.address, dex=dex)
+
+        for asset_position in dex_state.get("assetPositions", []):
+            coin = asset_position.get('position', {}).get('coin')
+            if not coin:
+                continue
+
+            try:
+                # Use the default exchange for the default DEX, get/create
+                # per-DEX exchange for extra DEXes
+                if dex == "" or dex is None:
+                    dex_exchange = exchange
+                else:
+                    dex_exchange = hyperliquid_utils.get_exchange(dex=dex)
+                    if not dex_exchange:
+                        errors.append((coin, f"No exchange for DEX '{dex}'"))
+                        continue
+
+                dex_exchange.market_close(coin)
+                closed.append(coin)
+            except Exception as e:  # pragma: no cover - exchange errors depend on external service
+                logger.error(f"Failed to close {coin} on DEX '{dex}': {e}", exc_info=True)
+                errors.append((coin, str(e)))
 
     return closed, errors

--- a/trade_pricing.py
+++ b/trade_pricing.py
@@ -14,7 +14,8 @@ class PriceSuggestion(NamedTuple):
 
 def _get_mid_price(coin: str) -> float:
     """Get current mid price for a coin."""
-    return float(hyperliquid_utils.info.all_mids()[coin])
+    dex = hyperliquid_utils.dex_supported(coin) or ""
+    return float(hyperliquid_utils.info.all_mids(dex=dex)[coin])
 
 
 async def get_price_suggestions(coin: str, mid: float, is_stop_loss: bool, is_long: bool) -> List[PriceSuggestion]:


### PR DESCRIPTION
## Summary

Refactors the trade execution layer to support builder-deployed perp DEXes (e.g. XYZ) and handle isolated-only leverage tokens correctly.

## Changes

### DEX-aware trading
- get_exchange(dex="") now caches per-DEX Exchange instances
- dex_supported(coin) detects the DEX from the {dex_name}: prefix
- open_order() routes to the correct DEX exchange based on the coin
- calculate_available_margin(dex="") queries the correct DEX user state

### Isolated-only token handling
- get_isolated_only(coin) checks the onlyIsolated flag from per-DEX meta()
- determine_leverage_mode(coin) forces isolated for onlyIsolated tokens

### Close/exit across DEXes
- close_all_positions_core() iterates all configured DEXes
- exit_position() shows positions from all DEXes
- exit_selected_coin() routes market_close() to the correct DEX

## Testing

All 623 tests pass (94 trade-specific tests).