### PR TITLE
fix: include XYZ DEX coins in coin selection for /long and /short

### DIFF
--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -261,16 +261,16 @@ class HyperliquidUtils:
         coin_data: List[Dict[str, Any]] = response_data[1]
         coins: list[tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
 
-        # Extra DEX coins
+        # Extra DEX coins — meta() supports dex, meta_and_asset_ctxs() does not
         for dex in self._extra_dexes:
             try:
-                dex_ctxs = self.info.meta_and_asset_ctxs(dex=dex)
-                dex_universe = dex_ctxs[0]['universe']
-                dex_coin_data = dex_ctxs[1]
-                coins.extend(
-                    (u["name"], float(c.get("dayNtlVlm", 0)))
-                    for u, c in zip(dex_universe, dex_coin_data)
-                )
+                dex_meta = self.info.meta(dex=dex)
+                dex_mids = self.info.all_mids(dex=dex)
+                for asset_info in dex_meta.get("universe", []):
+                    coin = asset_info["name"]
+                    # Use mid price as a rough volume proxy for ordering
+                    mid = float(dex_mids.get(coin, 0))
+                    coins.append((coin, mid))
             except Exception as e:
                 logger.warning(f"Failed to fetch coins for DEX '{dex}': {e}")
 


### PR DESCRIPTION
## Problem

When opening a position via `/long` or `/short`, XYZ DEX coins (xyz:AAPL, xyz:SPCX, etc.) don't appear in the coin selection list — only default Hyperliquid tokens are shown.

## Root Cause

Two bugs:

1. `meta_and_asset_ctxs()` does not accept a `dex` parameter in the SDK. The code was calling `self.info.meta_and_asset_ctxs(dex=dex)` which raised a TypeError that was silently swallowed by the `try/except`, so extra DEX coins were never loaded.

2. The commit containing the multi-DEX coin listing (95c3177) was pushed to the fork after PR #19 merged and never got its own PR, so it was never deployed.

## Fix
- Replace `meta_and_asset_ctxs(dex=dex)` with `meta(dex=dex)` + `all_mids(dex=dex)` — both of which properly accept a `dex` parameter
- Mid prices are used as a rough ordering proxy (volume data isn’t available per-DEX)

## Testing

All 624 tests pass.