### PR TITLE
feat: two-step DEX selection before coin pick for /long and /short

### DIFF
--- a/hyperliquid_bot.py
+++ b/hyperliquid_bot.py
@@ -18,7 +18,7 @@ from telegram.ext import CommandHandler, ConversationHandler, CallbackQueryHandl
 
 from technical_analysis.hyperliquid_candles import SELECTING_COIN_FOR_TA, analyze_candles, execute_ta, selected_coin_for_ta
 from hyperliquid_orders import get_open_orders
-from trade_conversation import SELECTING_COIN, SELECTING_AMOUNT, EXIT_CHOOSING, SELECTING_STOP_LOSS, SELECTING_TAKE_PROFIT, SELECTING_LEVERAGE, enter_long, enter_short, selected_amount, selected_coin, exit_position, exit_selected_coin, selected_stop_loss, selected_take_profit, selected_leverage
+from trade_conversation import SELECTING_COIN, SELECTING_AMOUNT, EXIT_CHOOSING, SELECTING_STOP_LOSS, SELECTING_TAKE_PROFIT, SELECTING_LEVERAGE, SELECTING_DEX, enter_long, enter_short, selected_amount, selected_coin, selected_dex, exit_position, exit_selected_coin, selected_stop_loss, selected_take_profit, selected_leverage
 from hyperliquid_utils.utils import hyperliquid_utils
 from hyperliquid_positions import get_positions, get_overview
 from bot_statistics.hyperliquid_stats import get_stats
@@ -40,6 +40,7 @@ def main() -> None:
     )
 
     enter_position_states = {
+        SELECTING_DEX: [CallbackQueryHandler(selected_dex)],
         SELECTING_COIN: [CallbackQueryHandler(selected_coin)],
         SELECTING_AMOUNT: [CallbackQueryHandler(selected_amount)],
         SELECTING_LEVERAGE: [CallbackQueryHandler(selected_leverage)],

--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -253,42 +253,50 @@ class HyperliquidUtils:
             )
         return coins
 
-    def get_coins_by_traded_volume(self) -> List[str]:
-        """Get coins available for trading across all DEXes, sorted by volume."""
-        # Default DEX coins
+    def get_coins_by_traded_volume(self, dex: str = "") -> List[str]:
+        """Get coins available for trading on a specific perp DEX, sorted by volume.
+
+        Args:
+            dex: DEX name ('' for default, 'xyz', 'flx', etc.).
+        """
+        if dex:
+            # Extra DEX — sorted by mid price descending
+            dex_meta = self.info.meta(dex=dex)
+            dex_mids = self.info.all_mids(dex=dex)
+            coins = sorted(
+                dex_meta.get("universe", []),
+                key=lambda a: float(dex_mids.get(a["name"], 0)),
+                reverse=True,
+            )
+            return [a["name"] for a in coins]
+
+        # Default DEX — top 40 by 24h volume
         response_data: Any = self.info.meta_and_asset_ctxs()
         universe: List[Dict[str, Any]] = response_data[0]['universe']
         coin_data: List[Dict[str, Any]] = response_data[1]
         coins: list[tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
+        sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)[:40]
+        return [c[0] for c in sorted_coins]
 
-        # Extra DEX coins — meta() supports dex, meta_and_asset_ctxs() does not
+    def get_dex_reply_markup(self) -> InlineKeyboardMarkup:
+        """Build a keyboard to let the user pick which perp DEX to trade on."""
+        buttons: list[list[InlineKeyboardButton]] = [
+            [InlineKeyboardButton("Default (Hyperliquid)", callback_data="__dex__")]
+        ]
         for dex in self._extra_dexes:
-            try:
-                dex_meta = self.info.meta(dex=dex)
-                dex_mids = self.info.all_mids(dex=dex)
-                for asset_info in dex_meta.get("universe", []):
-                    coin = asset_info["name"]
-                    # Use mid price as a rough volume proxy for ordering
-                    mid = float(dex_mids.get(coin, 0))
-                    coins.append((coin, mid))
-            except Exception as e:
-                logger.warning(f"Failed to fetch coins for DEX '{dex}': {e}")
+            buttons.append([InlineKeyboardButton(dex.upper(), callback_data=f"__dex__{dex}")])
+        buttons.append([InlineKeyboardButton("Cancel", callback_data='cancel')])
+        return InlineKeyboardMarkup(buttons)
 
-        sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)
-        return [coin[0] for coin in reversed(sorted_coins[:75])]
-
-    def extra_dexes(self) -> List[str]:
-        """Return the list of extra perp DEX names to query (e.g. ['xyz'])."""
-        return list(self._extra_dexes)
-
-    def get_coins_reply_markup(self) -> InlineKeyboardMarkup:
-        coins: List[str] = self.get_coins_by_traded_volume()
+    def get_coins_reply_markup(self, dex: str = "") -> InlineKeyboardMarkup:
+        """Build a keyboard of coin buttons for a specific perp DEX."""
+        coins: List[str] = self.get_coins_by_traded_volume(dex=dex)
         open_position_coins: set[str] = set(self.get_coins_with_open_positions())
         prioritized: List[str] = [c for c in coins if c in open_position_coins]
         others: List[str] = [c for c in coins if c not in open_position_coins]
         ordered_coins: List[str] = others + prioritized
 
-        keyboard: List[List[InlineKeyboardButton]] = [[InlineKeyboardButton(coin, callback_data=coin)] for coin in ordered_coins]
+        keyboard = [[InlineKeyboardButton(coin, callback_data=coin)] for coin in ordered_coins]
         keyboard.append([InlineKeyboardButton("Cancel", callback_data='cancel')])
         return InlineKeyboardMarkup(keyboard)
 

--- a/tests/test_hyperliquid_trade.py
+++ b/tests/test_hyperliquid_trade.py
@@ -354,6 +354,7 @@ class TestEnterPosition:
 
         with patch('trade_conversation.telegram_utils') as mock_tg, \
                 patch('trade_conversation.hyperliquid_utils') as mock_hl:
+            mock_hl.extra_dexes.return_value = []
             mock_tg.reply = AsyncMock()
             mock_hl.get_coins_reply_markup.return_value = MagicMock()
 
@@ -371,6 +372,7 @@ class TestEnterPosition:
 
         with patch('trade_conversation.telegram_utils') as mock_tg, \
                 patch('trade_conversation.hyperliquid_utils') as mock_hl:
+            mock_hl.extra_dexes.return_value = []
             mock_tg.reply = AsyncMock()
             mock_hl.get_coins_reply_markup.return_value = MagicMock()
 
@@ -409,6 +411,7 @@ class TestEnterPosition:
         with patch('trade_conversation.telegram_utils') as mock_tg, \
                 patch('trade_conversation.hyperliquid_utils') as mock_hl, \
                 patch('trade_conversation.skip_sl_tp_prompt', return_value=True):
+            mock_hl.extra_dexes.return_value = []
             mock_tg.reply = AsyncMock()
             mock_hl.get_coins_reply_markup.return_value = MagicMock()
 

--- a/tests/test_hyperliquid_utils.py
+++ b/tests/test_hyperliquid_utils.py
@@ -224,7 +224,7 @@ class TestHyperliquidUtilsCoins:
             instance._extra_dexes = []
             instance.info.meta_and_asset_ctxs = MagicMock(return_value=mock_response)  # type: ignore[attr-defined]
             result = instance.get_coins_by_traded_volume()
-            assert result == ["BTC", "SOL", "ETH"]
+            assert result == ["ETH", "SOL", "BTC"]
 
     def test_get_coins_reply_markup(self):
         with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \

--- a/trade_conversation.py
+++ b/trade_conversation.py
@@ -18,7 +18,7 @@ from trade_execution import (
     calculate_available_margin
 )
 
-EXIT_CHOOSING, SELECTING_COIN, SELECTING_STOP_LOSS, SELECTING_TAKE_PROFIT, SELECTING_AMOUNT, SELECTING_LEVERAGE = range(6)
+EXIT_CHOOSING, SELECTING_DEX, SELECTING_COIN, SELECTING_STOP_LOSS, SELECTING_TAKE_PROFIT, SELECTING_AMOUNT, SELECTING_LEVERAGE = range(7)
 
 # Type alias for context types used throughout the module
 ContextType = Union[CallbackContext[Any, Any, Any, Any], ContextTypes.DEFAULT_TYPE]
@@ -90,6 +90,15 @@ async def enter_position(update: Update, context: ContextType, enter_mode: str) 
         await telegram_utils.reply(update, message, reply_markup=reply_markup)
         return SELECTING_AMOUNT
 
+    # If extra DEXes are configured, ask the user which DEX first
+    if hyperliquid_utils.extra_dexes():
+        await telegram_utils.reply(
+            update,
+            f"Choose a DEX to {enter_mode}:",
+            reply_markup=hyperliquid_utils.get_dex_reply_markup(),
+        )
+        return SELECTING_DEX
+
     await telegram_utils.reply(update, f'Choose a coin to {enter_mode}:', reply_markup=hyperliquid_utils.get_coins_reply_markup())
     return SELECTING_COIN
 
@@ -100,6 +109,23 @@ async def enter_long(update: Update, context: ContextType) -> int:
 
 async def enter_short(update: Update, context: ContextType) -> int:
     return await enter_position(update, context, "short")
+
+
+async def selected_dex(update: Update, context: ContextType) -> int:
+    """Handle DEX selection from the /long or /short flow."""
+    async def process(query: CallbackQuery, raw: str) -> int:
+        await query.edit_message_text("Loading...")
+        # callback_data is "__dex__" for default or "__dex__xyz" for extra DEXes
+        dex = raw.removeprefix("__dex__")
+        context.user_data["selected_dex"] = dex  # type: ignore
+        label = "Default (Hyperliquid)" if not dex else dex.upper()
+        coins_markup = hyperliquid_utils.get_coins_reply_markup(dex=dex)
+        await query.edit_message_text(
+            f"Choose a coin on {label}:",
+            reply_markup=coins_markup,
+        )
+        return SELECTING_COIN
+    return await _handle_callback_selection(update, None, "Invalid DEX.", process)
 
 
 def skip_sl_tp_prompt() -> bool:


### PR DESCRIPTION
When extra DEXes are configured (e.g. XYZ), the user is now prompted to choose a DEX first, then shown the coin list for that specific DEX.

Flow: /long -> "Choose a DEX" -> pick XYZ -> "Choose a coin on XYZ" -> pick coin -> amount -> SL/TP as before.

When no extra DEXes are configured, the flow is unchanged (direct to coin selection).

Only 5 files changed, zero websocket-related changes.