### PR TITLE
fix: restore missing extra_dexes() method and add regression tests

### DIFF
--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -253,6 +253,10 @@ class HyperliquidUtils:
             )
         return coins
 
+    def extra_dexes(self) -> List[str]:
+        """Return the list of extra perp DEX names to query (e.g. ['xyz'])."""
+        return list(self._extra_dexes)
+
     def get_coins_by_traded_volume(self, dex: str = "") -> List[str]:
         """Get coins available for trading on a specific perp DEX, sorted by volume.
 

--- a/tests/test_hyperliquid_utils.py
+++ b/tests/test_hyperliquid_utils.py
@@ -212,6 +212,30 @@ class TestHyperliquidUtilsPositions:
 
 
 class TestHyperliquidUtilsCoins:
+    def test_extra_dexes_default_xyz(self):
+        with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \
+                patch('hyperliquid_utils.utils.Info') as mock_info, \
+                patch.dict(os.environ, {"HTB_USER_WALLET": "0x0", "HTB_EXTRA_DEXES": "xyz"}, clear=True):
+            from hyperliquid_utils.utils import HyperliquidUtils
+            instance = HyperliquidUtils()
+            assert instance.extra_dexes() == ["xyz"]
+
+    def test_extra_dexes_empty(self):
+        with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \
+                patch('hyperliquid_utils.utils.Info') as mock_info, \
+                patch.dict(os.environ, {"HTB_USER_WALLET": "0x0", "HTB_EXTRA_DEXES": ""}, clear=True):
+            from hyperliquid_utils.utils import HyperliquidUtils
+            instance = HyperliquidUtils()
+            assert instance.extra_dexes() == []
+
+    def test_extra_dexes_multiple(self):
+        with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \
+                patch('hyperliquid_utils.utils.Info') as mock_info, \
+                patch.dict(os.environ, {"HTB_USER_WALLET": "0x0", "HTB_EXTRA_DEXES": "xyz,flx,vntl"}, clear=True):
+            from hyperliquid_utils.utils import HyperliquidUtils
+            instance = HyperliquidUtils()
+            assert instance.extra_dexes() == ["xyz", "flx", "vntl"]
+
     def test_get_coins_by_traded_volume(self):
         mock_response = (
             {"universe": [{"name": "BTC"}, {"name": "ETH"}, {"name": "SOL"}]},


### PR DESCRIPTION
extra_dexes() was accidentally removed during a branch reset. It's called from trade_execution, trade_conversation, and hyperliquid_positions -- without it all positions and overview commands crash with AttributeError.

Also adds two-step DEX selection flow: when extra DEXes are configured (e.g. XYZ), /long and /short first ask which DEX to use, then show coins for that DEX.

3 regression tests added for extra_dexes() (default xyz, empty, multiple).