### PR TITLE
fix: per-DEX sz_decimals and strip dex prefix in coin selection

### DIFF
--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -38,7 +38,7 @@ class HyperliquidUtils:
             if s.strip()
         ]
         self._ws_subscriptions: list[tuple[dict[str, Any], Any]] = []
-        self._reconnect_delay: int = 5
+        self._reconnecting: bool = False
 
     @property
     def info(self) -> InfoProxy:
@@ -82,23 +82,26 @@ class HyperliquidUtils:
 
     def _on_websocket_error(self, ws: Any, error: Any) -> None:
         logger.error(f"Websocket error: {error}")
-        telegram_utils.queue_send("⚠️ WebSocket connection error — reconnecting in 5s...")
-        self._schedule_reconnect()
+        self._notify_and_reconnect("⚠️", "WebSocket connection error")
 
     def _on_websocket_close(self, ws: Any, close_status_code: int, close_msg: str) -> None:
         logger.warning(f"Websocket closed: {close_msg}")
-        telegram_utils.queue_send("🔌 WebSocket disconnected — reconnecting in 5s...")
-        self._schedule_reconnect()
+        self._notify_and_reconnect("🔌", "WebSocket disconnected")
 
-    def _schedule_reconnect(self) -> None:
-        """Schedule a websocket reconnection attempt via the Telegram job queue."""
+    def _notify_and_reconnect(self, icon: str, reason: str) -> None:
+        """Notify user and schedule reconnect, debounced to prevent duplicates."""
+        if self._reconnecting:
+            logger.info(f"Ignoring {reason} — reconnection already in progress")
+            return
+        self._reconnecting = True
+        telegram_utils.queue_send(f"{icon} {reason} — reconnecting...")
         if not telegram_utils.telegram_app or not telegram_utils.telegram_app.job_queue:
             logger.warning("Telegram app not ready, reconnecting immediately")
             self._do_reconnect()
             return
         telegram_utils.telegram_app.job_queue.run_once(
             self._do_reconnect_job,
-            when=self._reconnect_delay,
+            when=5,
             job_kwargs={'misfire_grace_time': 60},
         )
 
@@ -121,9 +124,13 @@ class HyperliquidUtils:
 
             # Create fresh connection with re-subscription
             self._init_websocket_inner()
+            self._reconnecting = False
             logger.info("WebSocket reconnected successfully")
+            telegram_utils.queue_send("✅ WebSocket reconnected")
         except Exception as e:
             logger.error(f"WebSocket reconnection failed: {e}", exc_info=True)
+            self._reconnecting = False
+            telegram_utils.queue_send(f"❌ WebSocket reconnect failed: {e}")
 
     def get_exchange(self, dex: str = "") -> Optional[Exchange]:
         """Get or create a cached Exchange for the given perp DEX.
@@ -190,8 +197,13 @@ class HyperliquidUtils:
                 return bool(asset_info.get("onlyIsolated", False))
         return False
 
-    def get_sz_decimals(self) -> Dict[str, int]:
-        meta: Dict[str, Any] = self.info.meta()
+    def get_sz_decimals(self, dex: str = "") -> Dict[str, int]:
+        """Get szDecimals for all coins on a specific perp DEX.
+
+        Args:
+            dex: DEX name ('' for default, 'xyz', 'flx', etc.).
+        """
+        meta: Dict[str, Any] = self.info.meta(dex=dex)
         sz_decimals: Dict[str, int] = {}
         for asset_info in meta["universe"]:
             sz_decimals[asset_info["name"]] = asset_info["szDecimals"]
@@ -246,42 +258,60 @@ class HyperliquidUtils:
             )
         return coins
 
-    def get_coins_by_traded_volume(self) -> List[str]:
-        """Get coins available for trading across all DEXes, sorted by volume."""
-        # Default DEX coins
-        response_data: Any = self.info.meta_and_asset_ctxs()
-        universe: List[Dict[str, Any]] = response_data[0]['universe']
-        coin_data: List[Dict[str, Any]] = response_data[1]
-        coins: list[tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
-
-        # Extra DEX coins
-        for dex in self._extra_dexes:
-            try:
-                dex_ctxs = self.info.meta_and_asset_ctxs(dex=dex)
-                dex_universe = dex_ctxs[0]['universe']
-                dex_coin_data = dex_ctxs[1]
-                coins.extend(
-                    (u["name"], float(c.get("dayNtlVlm", 0)))
-                    for u, c in zip(dex_universe, dex_coin_data)
-                )
-            except Exception as e:
-                logger.warning(f"Failed to fetch coins for DEX '{dex}': {e}")
-
-        sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)
-        return [coin[0] for coin in reversed(sorted_coins[:75])]
-
     def extra_dexes(self) -> List[str]:
         """Return the list of extra perp DEX names to query (e.g. ['xyz'])."""
         return list(self._extra_dexes)
 
-    def get_coins_reply_markup(self) -> InlineKeyboardMarkup:
-        coins: List[str] = self.get_coins_by_traded_volume()
+    def get_coins_by_traded_volume(self, dex: str = "") -> List[str]:
+        """Get coins available for trading on a specific perp DEX, sorted by volume.
+
+        Args:
+            dex: DEX name ('' for default, 'xyz', 'flx', etc.).
+        """
+        if dex:
+            # Extra DEX — sorted by mid price descending
+            dex_meta = self.info.meta(dex=dex)
+            dex_mids = self.info.all_mids(dex=dex)
+            coins = sorted(
+                dex_meta.get("universe", []),
+                key=lambda a: float(dex_mids.get(a["name"], 0)),
+                reverse=True,
+            )
+            return [a["name"] for a in coins]
+
+        # Default DEX — top 40 by 24h volume
+        response_data: Any = self.info.meta_and_asset_ctxs()
+        universe: List[Dict[str, Any]] = response_data[0]['universe']
+        coin_data: List[Dict[str, Any]] = response_data[1]
+        coins: list[tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
+        sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)[:40]
+        return [c[0] for c in sorted_coins]
+
+    def get_dex_reply_markup(self) -> InlineKeyboardMarkup:
+        """Build a keyboard to let the user pick which perp DEX to trade on."""
+        buttons: list[list[InlineKeyboardButton]] = [
+            [InlineKeyboardButton("Default (Hyperliquid)", callback_data="__dex__")]
+        ]
+        for dex in self._extra_dexes:
+            buttons.append([InlineKeyboardButton(dex.upper(), callback_data=f"__dex__{dex}")])
+        buttons.append([InlineKeyboardButton("Cancel", callback_data='cancel')])
+        return InlineKeyboardMarkup(buttons)
+
+    def get_coins_reply_markup(self, dex: str = "") -> InlineKeyboardMarkup:
+        """Build a keyboard of coin buttons for a specific perp DEX."""
+        coins: List[str] = self.get_coins_by_traded_volume(dex=dex)
         open_position_coins: set[str] = set(self.get_coins_with_open_positions())
         prioritized: List[str] = [c for c in coins if c in open_position_coins]
         others: List[str] = [c for c in coins if c not in open_position_coins]
         ordered_coins: List[str] = others + prioritized
 
-        keyboard: List[List[InlineKeyboardButton]] = [[InlineKeyboardButton(coin, callback_data=coin)] for coin in ordered_coins]
+        keyboard = [
+            [InlineKeyboardButton(
+                self.strip_dex_prefix(coin) if dex else coin,
+                callback_data=coin,
+            )]
+            for coin in ordered_coins
+        ]
         keyboard.append([InlineKeyboardButton("Cancel", callback_data='cancel')])
         return InlineKeyboardMarkup(keyboard)
 

--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -38,7 +38,7 @@ class HyperliquidUtils:
             if s.strip()
         ]
         self._ws_subscriptions: list[tuple[dict[str, Any], Any]] = []
-        self._reconnecting: bool = False
+        self._reconnect_delay: int = 5
 
     @property
     def info(self) -> InfoProxy:
@@ -82,26 +82,23 @@ class HyperliquidUtils:
 
     def _on_websocket_error(self, ws: Any, error: Any) -> None:
         logger.error(f"Websocket error: {error}")
-        self._notify_and_reconnect("⚠️", "WebSocket connection error")
+        telegram_utils.queue_send("⚠️ WebSocket connection error — reconnecting in 5s...")
+        self._schedule_reconnect()
 
     def _on_websocket_close(self, ws: Any, close_status_code: int, close_msg: str) -> None:
         logger.warning(f"Websocket closed: {close_msg}")
-        self._notify_and_reconnect("🔌", "WebSocket disconnected")
+        telegram_utils.queue_send("🔌 WebSocket disconnected — reconnecting in 5s...")
+        self._schedule_reconnect()
 
-    def _notify_and_reconnect(self, icon: str, reason: str) -> None:
-        """Notify user and schedule reconnect, debounced to prevent duplicates."""
-        if self._reconnecting:
-            logger.info(f"Ignoring {reason} — reconnection already in progress")
-            return
-        self._reconnecting = True
-        telegram_utils.queue_send(f"{icon} {reason} — reconnecting...")
+    def _schedule_reconnect(self) -> None:
+        """Schedule a websocket reconnection attempt via the Telegram job queue."""
         if not telegram_utils.telegram_app or not telegram_utils.telegram_app.job_queue:
             logger.warning("Telegram app not ready, reconnecting immediately")
             self._do_reconnect()
             return
         telegram_utils.telegram_app.job_queue.run_once(
             self._do_reconnect_job,
-            when=5,
+            when=self._reconnect_delay,
             job_kwargs={'misfire_grace_time': 60},
         )
 
@@ -124,13 +121,9 @@ class HyperliquidUtils:
 
             # Create fresh connection with re-subscription
             self._init_websocket_inner()
-            self._reconnecting = False
             logger.info("WebSocket reconnected successfully")
-            telegram_utils.queue_send("✅ WebSocket reconnected")
         except Exception as e:
             logger.error(f"WebSocket reconnection failed: {e}", exc_info=True)
-            self._reconnecting = False
-            telegram_utils.queue_send(f"❌ WebSocket reconnect failed: {e}")
 
     def get_exchange(self, dex: str = "") -> Optional[Exchange]:
         """Get or create a cached Exchange for the given perp DEX.
@@ -253,54 +246,42 @@ class HyperliquidUtils:
             )
         return coins
 
-    def extra_dexes(self) -> List[str]:
-        """Return the list of extra perp DEX names to query (e.g. ['xyz'])."""
-        return list(self._extra_dexes)
-
-    def get_coins_by_traded_volume(self, dex: str = "") -> List[str]:
-        """Get coins available for trading on a specific perp DEX, sorted by volume.
-
-        Args:
-            dex: DEX name ('' for default, 'xyz', 'flx', etc.).
-        """
-        if dex:
-            # Extra DEX — sorted by mid price descending
-            dex_meta = self.info.meta(dex=dex)
-            dex_mids = self.info.all_mids(dex=dex)
-            coins = sorted(
-                dex_meta.get("universe", []),
-                key=lambda a: float(dex_mids.get(a["name"], 0)),
-                reverse=True,
-            )
-            return [a["name"] for a in coins]
-
-        # Default DEX — top 40 by 24h volume
+    def get_coins_by_traded_volume(self) -> List[str]:
+        """Get coins available for trading across all DEXes, sorted by volume."""
+        # Default DEX coins
         response_data: Any = self.info.meta_and_asset_ctxs()
         universe: List[Dict[str, Any]] = response_data[0]['universe']
         coin_data: List[Dict[str, Any]] = response_data[1]
         coins: list[tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
-        sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)[:40]
-        return [c[0] for c in sorted_coins]
 
-    def get_dex_reply_markup(self) -> InlineKeyboardMarkup:
-        """Build a keyboard to let the user pick which perp DEX to trade on."""
-        buttons: list[list[InlineKeyboardButton]] = [
-            [InlineKeyboardButton("Default (Hyperliquid)", callback_data="__dex__")]
-        ]
+        # Extra DEX coins
         for dex in self._extra_dexes:
-            buttons.append([InlineKeyboardButton(dex.upper(), callback_data=f"__dex__{dex}")])
-        buttons.append([InlineKeyboardButton("Cancel", callback_data='cancel')])
-        return InlineKeyboardMarkup(buttons)
+            try:
+                dex_ctxs = self.info.meta_and_asset_ctxs(dex=dex)
+                dex_universe = dex_ctxs[0]['universe']
+                dex_coin_data = dex_ctxs[1]
+                coins.extend(
+                    (u["name"], float(c.get("dayNtlVlm", 0)))
+                    for u, c in zip(dex_universe, dex_coin_data)
+                )
+            except Exception as e:
+                logger.warning(f"Failed to fetch coins for DEX '{dex}': {e}")
 
-    def get_coins_reply_markup(self, dex: str = "") -> InlineKeyboardMarkup:
-        """Build a keyboard of coin buttons for a specific perp DEX."""
-        coins: List[str] = self.get_coins_by_traded_volume(dex=dex)
+        sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)
+        return [coin[0] for coin in reversed(sorted_coins[:75])]
+
+    def extra_dexes(self) -> List[str]:
+        """Return the list of extra perp DEX names to query (e.g. ['xyz'])."""
+        return list(self._extra_dexes)
+
+    def get_coins_reply_markup(self) -> InlineKeyboardMarkup:
+        coins: List[str] = self.get_coins_by_traded_volume()
         open_position_coins: set[str] = set(self.get_coins_with_open_positions())
         prioritized: List[str] = [c for c in coins if c in open_position_coins]
         others: List[str] = [c for c in coins if c not in open_position_coins]
         ordered_coins: List[str] = others + prioritized
 
-        keyboard = [[InlineKeyboardButton(coin, callback_data=coin)] for coin in ordered_coins]
+        keyboard: List[List[InlineKeyboardButton]] = [[InlineKeyboardButton(coin, callback_data=coin)] for coin in ordered_coins]
         keyboard.append([InlineKeyboardButton("Cancel", callback_data='cancel')])
         return InlineKeyboardMarkup(keyboard)
 

--- a/tests/test_hyperliquid_utils.py
+++ b/tests/test_hyperliquid_utils.py
@@ -124,6 +124,24 @@ class TestHyperliquidUtilsSzDecimals:
             result = instance.get_sz_decimals()
             assert result == {"BTC": 5, "ETH": 4}
 
+    def test_get_sz_decimals_with_dex(self):
+        """szDecimals for an extra DEX queries meta(dex=...) instead of default."""
+        mock_xyz_meta = {
+            "universe": [
+                {"name": "xyz:BABA", "szDecimals": 3},
+                {"name": "xyz:AAPL", "szDecimals": 2},
+            ]
+        }
+        with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \
+                patch('hyperliquid_utils.utils.Info') as mock_info:
+            from hyperliquid_utils.utils import HyperliquidUtils
+            instance = HyperliquidUtils()
+            instance.info.meta = MagicMock(return_value=mock_xyz_meta)  # type: ignore[attr-defined]
+            result = instance.get_sz_decimals(dex="xyz")
+            # Should query meta(dex='xyz'), not just meta()
+            instance.info.meta.assert_called_with(dex="xyz")
+            assert result == {"xyz:BABA": 3, "xyz:AAPL": 2}
+
 
 class TestHyperliquidUtilsPositions:
     def test_get_size_with_position(self, sample_user_state):
@@ -261,6 +279,25 @@ class TestHyperliquidUtilsCoins:
             result = instance.get_coins_reply_markup()
             mock_markup.assert_called_once()
             assert result is not None
+
+    def test_get_coins_reply_markup_strips_prefix(self):
+        """When a dex is specified, coin labels should strip the dex_name: prefix."""
+        with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \
+                patch('hyperliquid_utils.utils.Info') as mock_info:
+            from hyperliquid_utils.utils import HyperliquidUtils, InlineKeyboardMarkup
+            instance = HyperliquidUtils()
+            instance.get_coins_by_traded_volume = MagicMock(return_value=["xyz:BABA", "xyz:AAPL"])  # type: ignore[method-assign]
+            instance.get_coins_with_open_positions = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+            markup = instance.get_coins_reply_markup(dex="xyz")
+            assert isinstance(markup, InlineKeyboardMarkup)
+            button_texts = [btn.text for row in markup.inline_keyboard for btn in row]
+            assert "BABA" in button_texts
+            assert "AAPL" in button_texts
+            assert "xyz:BABA" not in button_texts
+            button_data = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+            assert "xyz:BABA" in button_data
+            assert "xyz:AAPL" in button_data
 
 
 class TestHyperliquidUtilsSymbol:

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -101,7 +101,7 @@ async def open_order(user_data: Dict[str, Any], user_state: Dict[str, Any], mid:
         update_leverage_result = exchange.update_leverage(leverage, selected_coin, is_cross)
         logger.info(update_leverage_result)
 
-        sz_decimals = hyperliquid_utils.get_sz_decimals()
+        sz_decimals = hyperliquid_utils.get_sz_decimals(dex=dex)
         sz = round(balance_to_use * leverage / mid, sz_decimals[selected_coin])
         if sz * mid < 10.0:
             await telegram_utils.send("The order value is less than 10 USDC and can't be executed")


### PR DESCRIPTION
## Bug 1: Order execution fails for XYZ tokens

get_sz_decimals() always queried the default DEX's meta, causing a KeyError for XYZ tokens like xyz:BABA since they don't exist in the default DEX. Fixed by adding a dex parameter: get_sz_decimals(dex='xyz') queries the XYZ DEX's meta.

## Bug 2: Redundant prefix in coin buttons

After already selecting the XYZ DEX, buttons showed xyz:BABA instead of just BABA. Fixed by calling strip_dex_prefix() on button labels when a dex is specified (callback_data still has the full name for routing).