### PR TITLE
fix: use per-DEX available margin in amount suggestions

### DIFF
--- a/trade_conversation.py
+++ b/trade_conversation.py
@@ -300,7 +300,8 @@ async def selected_coin(update: Update, context: ContextType) -> int:
 
 
 async def get_amount_suggestions(context: ContextType) -> Tuple[str, InlineKeyboardMarkup]:
-    available_margin = calculate_available_margin()
+    dex = context.user_data.get("selected_dex", "")  # type: ignore
+    available_margin = calculate_available_margin(dex=dex)
 
     keyboard = [
         [InlineKeyboardButton(f"{amount}% (~{fmt(available_margin * amount / 100.0)} USDC)", callback_data=str(amount))]


### PR DESCRIPTION
get_amount_suggestions() always called calculate_available_margin() without a dex parameter, so it showed percentages based on the default DEX's balance. When trading on an extra DEX (e.g. XYZ), the amounts were wrong, causing the minimum order check (sz * mid < 10 USDC) to fail.

Now reads selected_dex from user_data and passes it to calculate_available_margin(dex=dex).