### PR TITLE
fix: cap dex coin picker and rank by volume; keep held coins listed

### DIFF
--- a/hyperliquid_utils/hyperliquid_info_proxy.py
+++ b/hyperliquid_utils/hyperliquid_info_proxy.py
@@ -26,6 +26,22 @@ class InfoProxy:
     def __init__(self, info: Info) -> None:
         self._info = info
 
+    def meta_and_asset_ctxs(self, dex: str = "") -> Any:
+        """Fetch perp meta + asset ctxs for a DEX.
+
+        The underlying SDK's ``meta_and_asset_ctxs()`` never forwards a ``dex``
+        argument (it only posts ``{"type": "metaAndAssetCtxs"}``), so passing one
+        always raised a ``TypeError`` for builder DEXes (e.g. ``xyz``). The
+        exchange API *does* accept ``dex`` here, so for non-default DEXes we
+        post the DEX directly. Both paths are rate-limited identically.
+        """
+        if not dex:
+            result = self._info.meta_and_asset_ctxs()
+        else:
+            result = self._info.post("/info", {"type": "metaAndAssetCtxs", "dex": dex})
+        hyperliquid_rate_limiter.add_weight(self.WEIGHTS['meta_and_asset_ctxs'])
+        return result
+
     def __getattr__(self, name: str) -> Any:
         attr = getattr(self._info, name)
         if callable(attr):

--- a/hyperliquid_utils/utils.py
+++ b/hyperliquid_utils/utils.py
@@ -293,29 +293,39 @@ class HyperliquidUtils:
         return list(self._extra_dexes)
 
     def get_coins_by_traded_volume(self, dex: str = "") -> List[str]:
-        """Get coins available for trading on a specific perp DEX, sorted by volume.
+        """Get coins available for trading on a specific perp DEX, ranked by volume.
+
+        Both the default DEX and builder DEXes (e.g. ``xyz``, ``flx``) are ranked
+        by 24h notional volume, contributing the same UX.  The list is capped at
+        ``HTB_MAX_COINS`` (default 25) so the Telegram picker stays short instead
+        of forcing long scrolling (the default DEX previously used a hardcoded
+        top-40; extra DEXes returned every coin, e.g. ~117 on xyz).
+
+        Coins with an open position are always appended so they stay reachable
+        even if they fall below the volume cap — the caller prioritizes them to
+        the bottom of the picker, matching the "find my coin down there" feel.
 
         Args:
             dex: DEX name ('' for default, 'xyz', 'flx', etc.).
         """
-        if dex:
-            # Extra DEX — sorted by mid price descending
-            dex_meta = self.info.meta(dex=dex)
-            dex_mids = self.info.all_mids(dex=dex)
-            coins = sorted(
-                dex_meta.get("universe", []),
-                key=lambda a: float(dex_mids.get(a["name"], 0)),
-                reverse=True,
-            )
-            return [a["name"] for a in coins]
+        ctxs: Any = self.info.meta_and_asset_ctxs(dex=dex)
+        universe: List[Dict[str, Any]] = ctxs[0]['universe']
+        coin_data: List[Dict[str, Any]] = ctxs[1]
+        coins: list[tuple[str, float]] = [
+            (u["name"], float(c.get("dayNtlVlm", 0)))
+            for u, c in zip(universe, coin_data)
+        ]
+        max_coins = int(os.environ.get("HTB_MAX_COINS", "25"))
+        ranked = [c[0] for c in sorted(coins, key=lambda x: x[1], reverse=True)[:max_coins]]
 
-        # Default DEX — top 40 by 24h volume
-        response_data: Any = self.info.meta_and_asset_ctxs()
-        universe: List[Dict[str, Any]] = response_data[0]['universe']
-        coin_data: List[Dict[str, Any]] = response_data[1]
-        coins: list[tuple[str, float]] = [(u["name"], float(c["dayNtlVlm"])) for u, c in zip(universe, coin_data)]
-        sorted_coins = sorted(coins, key=lambda x: x[1], reverse=True)[:40]
-        return [c[0] for c in sorted_coins]
+        # Always keep coins with open positions in the list so the user can find
+        # them again even when their volume dropped below the cap.
+        prefix = f"{dex}:" if dex else ""
+        for coin in self.get_coins_with_open_positions():
+            if (prefix and coin.startswith(prefix)) or (not prefix and ":" not in coin):
+                if coin not in ranked:
+                    ranked.append(coin)
+        return ranked
 
     def get_dex_reply_markup(self) -> InlineKeyboardMarkup:
         """Build a keyboard to let the user pick which perp DEX to trade on."""

--- a/tests/test_hyperliquid_utils.py
+++ b/tests/test_hyperliquid_utils.py
@@ -267,8 +267,50 @@ class TestHyperliquidUtilsCoins:
             instance = HyperliquidUtils()
             instance._extra_dexes = []
             instance.info.meta_and_asset_ctxs = MagicMock(return_value=mock_response)  # type: ignore[attr-defined]
+            instance.get_coins_with_open_positions = MagicMock(return_value=[])  # type: ignore[method-assign]
             result = instance.get_coins_by_traded_volume()
             assert result == ["ETH", "SOL", "BTC"]
+
+    def test_get_coins_by_traded_volume_extra_dex_cap_and_open_positions(self):
+        """Builder-DEX coins rank by volume, are capped, and held coins stay listed.
+
+        With HTB_MAX_COINS=2 and an xyz open position that would fall outside the
+        top-2, the held coin must still be returned so it surfaces in the picker.
+        """
+        xyz_ctxs = (
+            {"universe": [{"name": f"xyz:C{i}"} for i in range(10)]},
+            [{"dayNtlVlm": str(1000 - i)} for i in range(10)],
+        )
+        with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \
+                patch('hyperliquid_utils.utils.Info') as mock_info, \
+                patch.dict(os.environ, {"HTB_MAX_COINS": "2"}, clear=False):
+            from hyperliquid_utils.utils import HyperliquidUtils
+            instance = HyperliquidUtils()
+            instance._extra_dexes = []
+            instance.info.meta_and_asset_ctxs = MagicMock(return_value=xyz_ctxs)  # type: ignore[attr-defined]
+            # held coin xyz:C9 has the lowest volume -> below the top-2 cap
+            instance.get_coins_with_open_positions = MagicMock(return_value=["xyz:C9"])  # type: ignore[method-assign]
+            result = instance.get_coins_by_traded_volume(dex="xyz")
+            assert result == ["xyz:C0", "xyz:C1", "xyz:C9"]
+            instance.info.meta_and_asset_ctxs.assert_called_with(dex="xyz")
+
+    def test_get_coins_by_traded_volume_cap_respected(self):
+        """Without an open position, the list is capped at HTB_MAX_COINS."""
+        xyz_ctxs = (
+            {"universe": [{"name": f"xyz:C{i}"} for i in range(10)]},
+            [{"dayNtlVlm": str(1000 - i)} for i in range(10)],
+        )
+        with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \
+                patch('hyperliquid_utils.utils.Info') as mock_info, \
+                patch.dict(os.environ, {"HTB_MAX_COINS": "5"}, clear=False):
+            from hyperliquid_utils.utils import HyperliquidUtils
+            instance = HyperliquidUtils()
+            instance._extra_dexes = []
+            instance.info.meta_and_asset_ctxs = MagicMock(return_value=xyz_ctxs)  # type: ignore[attr-defined]
+            instance.get_coins_with_open_positions = MagicMock(return_value=[])  # type: ignore[method-assign]
+            result = instance.get_coins_by_traded_volume(dex="xyz")
+            assert result == ["xyz:C0", "xyz:C1", "xyz:C2", "xyz:C3", "xyz:C4"]
+            assert len(result) == 5
 
     def test_get_coins_reply_markup(self):
         with patch('hyperliquid_utils.utils.InfoProxy') as mock_info_proxy, \


### PR DESCRIPTION
## Summary

Fixes the `/long` and `/short` coin picker for builder-DEX secondary markets (xyz, flx, …):
- **Extra DEXes now rank coins by 24h notional volume** (previously by mid-price), matching the default-DEX UX so the coin you want surfaces the same way.
- **Caps the picker** at `HTB_MAX_COINS` (default **25**, was hardcoded top-40 for default and unbounded ~117 for xyz), so you no longer have to scroll through a huge list.
- **Held coins always stay listed**: coins with an open position are appended even if their volume dropped below the cap, so you can still find/manage them.

## Root cause

`get_coins_by_traded_volume(dex)` had two divergent branches. The default DEX ranked by volume but was only capped at 40; extra DEXes (xyz) returned *every* token sorted by mid-price — ~117 on xyz — forcing heavy scrolling and burying low-price coins.

## Changes

- `hyperliquid_utils/utils.py` — unify both DEX branches on volume ranking + `HTB_MAX_COINS` cap; always include open-position coins.
- `hyperliquid_utils/hyperliquid_info_proxy.py` — add `meta_and_asset_ctxs(dex=...)` (the SDK doesn't forward `dex` to `metaAndAssetCtxs`; the API does). Rate-limit tracked like the default path.
- `tests/test_hyperliquid_utils.py` — tests for the cap, held-coin retention, and dex-aware ranking.

## Test

Full suite: **631 passed**.